### PR TITLE
don't warn on db creation

### DIFF
--- a/src/mem3_util.erl
+++ b/src/mem3_util.erl
@@ -200,7 +200,6 @@ n_val(undefined, NodeCount) ->
 n_val(N, NodeCount) when is_list(N) ->
     n_val(list_to_integer(N), NodeCount);
 n_val(N, NodeCount) when is_integer(NodeCount), N > NodeCount ->
-    couch_log:error("Request to create N=~p DB but only ~p node(s)", [N, NodeCount]),
     NodeCount;
 n_val(N, _) when N < 1 ->
     1;


### PR DESCRIPTION
do not warn on db creation if the user runs a
"single-node-cluster". given the suggestions i got on IRC
currently the best way is not to modify N and just let it default
to three, also for a cluster-of-one.

This closes COUCHDB-2594

This superseeds https://github.com/apache/couchdb-setup/pull/4#discussion_r35442125