### PR TITLE
Fix type spec for range field in #shard{}

### DIFF
--- a/include/mem3.hrl
+++ b/include/mem3.hrl
@@ -15,7 +15,7 @@
     name :: binary() | '_',
     node :: node() | '_',
     dbname :: binary(),
-    range :: [non_neg_integer() | '$1' | '$2'],
+    range :: [non_neg_integer() | '$1' | '$2'] | '_',
     ref :: reference() | 'undefined' | '_'
 }).
 
@@ -24,7 +24,7 @@
     name :: binary() | '_',
     node :: node() | '_',
     dbname :: binary(),
-    range :: [non_neg_integer() | '$1' | '$2'],
+    range :: [non_neg_integer() | '$1' | '$2'] | '_',
     ref :: reference() | 'undefined' | '_',
     order :: non_neg_integer() | 'undefined' | '_'
 }).


### PR DESCRIPTION
Add '_' as a valid value for range field to be able to remove complains
when we create ets match spec in mem3_shards:for_shard_name.